### PR TITLE
Fix issues with test failures

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -295,15 +295,15 @@ fn read_out_of_range() {
 
     let mut reader = BinaryReader::new(&mut stream);
 
-    if reader.read_f32().is_err() {
-        return;
-    }
+    reader.read_f32().expect("Failed to read f32");
 
-    if reader.read_f32().is_err() {
-        panic!("Out of range");
-    }
+    let was_error = reader.read_f32().is_err();
 
     cleanup("out_of_range");
+
+    if was_error {
+        panic!("Out of range");
+    }
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -309,19 +309,19 @@ fn read_out_of_range() {
 #[test]
 fn read_write_string() {
     let temp = "Hello World";
-    let mut stream = create_writer_stream("out_of_range");
+    let mut stream = create_writer_stream("read_write_string");
     let mut writer = BinaryWriter::new(&mut stream);
 
     writer
         .write_string(temp.to_string())
         .expect("Failed to write string");
-    let mut stream = create_reader_stream("out_of_range");
+    let mut stream = create_reader_stream("read_write_string");
 
     let mut reader = BinaryReader::new(&mut stream);
     let string = reader.read_string().expect("Failed to read string");
     assert_eq!(temp, string);
 
-    cleanup("out_of_range");
+    cleanup("read_write_string");
 }
 
 #[test]


### PR DESCRIPTION
These changes fix https://github.com/mathias234/binary-rs/issues/2 and also make sure the `out_of_range` temp file gets cleaned up prior to the test panicking (that it wasn't getting cleaned up was exposed after changing `read_write_string` to operate on a separate file).