### PR TITLE
Fix Memorystream::read() to advance the stream position

### DIFF
--- a/src/memorystream.rs
+++ b/src/memorystream.rs
@@ -44,6 +44,8 @@ impl Stream for Memorystream {
             idx += 1;
         }
 
+        self.position += buffer.len();
+
         Ok(buffer.len())
     }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -326,16 +326,17 @@ fn read_write_string() {
 
 #[test]
 fn read_write_from_memorystream() {
-    let temp = 5.0;
+    let valueA = 3.0;
+    let valueB = 5.0;
     let mut stream = Memorystream::new().expect("Error");
     let mut writer = BinaryWriter::new(&mut stream);
-    writer.write_f32(temp).expect("Failed to write f32");
-    writer.write_f32(temp).expect("Failed to write f32");
+    writer.write_f32(valueA).expect("Failed to write f32");
+    writer.write_f32(valueB).expect("Failed to write f32");
 
     let mut reader = BinaryReader::new(&mut stream);
     reader.seek_to(0).expect("Failed to seek");
     let value = reader.read_f32().expect("Failed to read f32");
-    assert_eq!(temp, value);
+    assert_eq!(valueA, value);
     let value = reader.read_f32().expect("Failed to read f32");
-    assert_eq!(temp, value);
+    assert_eq!(valueB, value);
 }


### PR DESCRIPTION
This PR is to fix #5 - updated the unit test to expose the failure and fixed the offending code in Memorystream.