### PR TITLE
Use thiserror to implement std::error::Error.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ license = "MIT"
 
 [dependencies]
 bincode = "1.2.1"
+thiserror = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate bincode;
 
 use std::string::FromUtf8Error;
+use thiserror::Error;
 
 use bincode::{deserialize, serialize};
 
@@ -11,10 +12,13 @@ pub struct BinaryReader<'a> {
     stream: &'a mut dyn Stream,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum BinaryError {
+    #[error(transparent)]
     StreamError(StreamError),
+    #[error(transparent)]
     BinCodeErr(Box<bincode::ErrorKind>),
+    #[error(transparent)]
     Utf8Error(FromUtf8Error),
 }
 
@@ -36,12 +40,17 @@ impl From<StreamError> for BinaryError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum StreamError {
+    #[error("failed to open stream")]
     OpenError,
+    #[error("failed to write to stream")]
     WriteError,
+    #[error("failed to read from stream")]
     ReadError,
+    #[error("failed to seek in stream")]
     SeekError,
+    #[error("failed to tell in stream")]
     TellError,
 }
 


### PR DESCRIPTION
Beforehand the error enums did not implement the `std::error::Error` trait which makes the error handling awkward when interacting with this library, for example I could not use the `?` operator to automatically return an `anyhow::Error`.