### PR TITLE
Implement std::io::{Read, Write} traits.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate bincode;
 
+use std::io::{Read, Write};
 use std::string::FromUtf8Error;
 use thiserror::Error;
 
@@ -20,6 +21,8 @@ pub enum BinaryError {
     BinCodeErr(Box<bincode::ErrorKind>),
     #[error(transparent)]
     Utf8Error(FromUtf8Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
 }
 
 impl From<FromUtf8Error> for BinaryError {
@@ -48,9 +51,7 @@ pub enum StreamError {
     Io(#[from] std::io::Error),
 }
 
-pub trait Stream {
-    fn write(&mut self, bytes: &Vec<u8>) -> Result<usize, StreamError>;
-    fn read(&mut self, buffer: &mut Vec<u8>) -> Result<usize, StreamError>;
+pub trait Stream: Read + Write {
     fn seek(&mut self, to: usize) -> Result<usize, StreamError>;
     fn tell(&mut self) -> Result<usize, StreamError>;
 }

--- a/src/memorystream.rs
+++ b/src/memorystream.rs
@@ -1,4 +1,5 @@
 use crate::{Stream, StreamError};
+use std::io::{Error, ErrorKind, Read, Write};
 
 pub struct Memorystream {
     buffer: Vec<u8>,
@@ -15,7 +16,39 @@ impl Memorystream {
 }
 
 impl Stream for Memorystream {
-    fn write(&mut self, bytes: &Vec<u8>) -> Result<usize, StreamError> {
+    fn seek(&mut self, to: usize) -> Result<usize, StreamError> {
+        self.position = to;
+        Ok(self.position)
+    }
+
+    fn tell(&mut self) -> Result<usize, StreamError> {
+        Ok(self.position)
+    }
+}
+
+impl Read for Memorystream {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        if self.position + buffer.len() > self.buffer.len() {
+            return Err(Error::new(
+                ErrorKind::UnexpectedEof,
+                StreamError::ReadPastEof,
+            ));
+        }
+
+        let mut idx = 0;
+        for i in self.position..self.position + buffer.len() {
+            buffer[idx] = self.buffer[i];
+            idx += 1;
+        }
+
+        self.position += buffer.len();
+
+        Ok(buffer.len())
+    }
+}
+
+impl Write for Memorystream {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
         let bytes_to_end = self.buffer.len() - self.position;
         if bytes.len() > bytes_to_end {
             let bytes_out_of_buffer = bytes.len() - bytes_to_end;
@@ -36,28 +69,7 @@ impl Stream for Memorystream {
         Ok(bytes.len())
     }
 
-    fn read(&mut self, buffer: &mut Vec<u8>) -> Result<usize, StreamError> {
-        if self.position + buffer.len() > self.buffer.len() {
-            return Err(StreamError::ReadPastEof);
-        }
-
-        let mut idx = 0;
-        for i in self.position..self.position + buffer.len() {
-            buffer[idx] = self.buffer[i];
-            idx += 1;
-        }
-
-        self.position += buffer.len();
-
-        Ok(buffer.len())
-    }
-
-    fn seek(&mut self, to: usize) -> Result<usize, StreamError> {
-        self.position = to;
-        Ok(self.position)
-    }
-
-    fn tell(&mut self) -> Result<usize, StreamError> {
-        Ok(self.position)
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }


### PR DESCRIPTION
I think this makes the `Stream` trait more idiomatic and compatible with other types that implement `Read` and `Write`.