### PR TITLE
Support From<Vec<u8>> on Memorystream.

### DIFF
--- a/src/memorystream.rs
+++ b/src/memorystream.rs
@@ -74,6 +74,15 @@ impl Write for Memorystream {
     }
 }
 
+impl From<Vec<u8>> for Memorystream {
+    fn from(buffer: Vec<u8>) -> Self {
+        Memorystream {
+            buffer,
+            position: 0,
+        }
+    }
+}
+
 impl Into<Vec<u8>> for Memorystream {
     fn into(self) -> Vec<u8> {
         self.buffer


### PR DESCRIPTION
Now we can go between buffers and memory streams bi-directionally.

Sorry, should have added this on the last PR!