### PR TITLE
Support 32 bit string length prefix.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binary_rw"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Mathias Danielsen <mathiasda98@hotmail.com>"]
 edition = "2021"
 
@@ -9,6 +9,9 @@ repository = "https://github.com/mathias234/binary-rs"
 readme = "README.md"
 keywords = ["binary", "reader", "writer"]
 license = "MIT"
+
+[features]
+wasm32 = []
 
 [dependencies]
 thiserror = "1"


### PR DESCRIPTION
Using the `wasm32` feature flag so that we have some platform
portability when it is desirable to support `wasm32` as well as
other platforms.