### PR TITLE
Split stream traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binary_rw"
-version = "2.0.3"
+version = "3.0.0"
 authors = ["Mathias Danielsen <mathiasda98@hotmail.com>"]
 edition = "2021"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,10 @@
 //! Otherwise string length is encoded using `usize` which
 //! may vary across platforms.
 #![deny(missing_docs)]
-use std::io::{Read, Write};
+use std::{
+    borrow::Borrow,
+    io::{Read, Write},
+};
 
 mod error;
 mod stream;
@@ -275,74 +278,74 @@ impl<'a> BinaryWriter<'a> {
     }
 
     /// Write a character to the stream.
-    pub fn write_char(&mut self, v: char) -> Result<usize> {
-        self.write_u32(v as u32)
+    pub fn write_char<V: Borrow<char>>(&mut self, v: V) -> Result<usize> {
+        self.write_u32(*v.borrow() as u32)
     }
 
     /// Write a `bool` to the stream.
-    pub fn write_bool(&mut self, value: bool) -> Result<usize> {
-        let written = self.write_u8(if value { 1 } else { 0 })?;
+    pub fn write_bool<V: Borrow<bool>>(&mut self, value: V) -> Result<usize> {
+        let written = self.write_u8(if *value.borrow() { 1 } else { 0 })?;
         Ok(written)
     }
 
     /// Write a `f32` to the stream.
-    pub fn write_f32(&mut self, value: f32) -> Result<usize> {
-        encode!(self.endian, &value, self.stream);
+    pub fn write_f32<V: Borrow<f32>>(&mut self, value: V) -> Result<usize> {
+        encode!(self.endian, value.borrow(), self.stream);
     }
 
     /// Write a `f64` to the stream.
-    pub fn write_f64(&mut self, value: f64) -> Result<usize> {
-        encode!(self.endian, &value, self.stream);
+    pub fn write_f64<V: Borrow<f64>>(&mut self, value: V) -> Result<usize> {
+        encode!(self.endian, value.borrow(), self.stream);
     }
 
     /// Write an `isize` to the stream.
-    pub fn write_isize(&mut self, value: isize) -> Result<usize> {
-        encode!(self.endian, &value, self.stream);
+    pub fn write_isize<V: Borrow<isize>>(&mut self, value: V) -> Result<usize> {
+        encode!(self.endian, value.borrow(), self.stream);
     }
 
     /// Write a `usize` to the stream.
-    pub fn write_usize(&mut self, value: usize) -> Result<usize> {
-        encode!(self.endian, &value, self.stream);
+    pub fn write_usize<V: Borrow<usize>>(&mut self, value: V) -> Result<usize> {
+        encode!(self.endian, value.borrow(), self.stream);
     }
 
     /// Write a `u64` to the stream.
-    pub fn write_u64(&mut self, value: u64) -> Result<usize> {
-        encode!(self.endian, &value, self.stream);
+    pub fn write_u64<V: Borrow<u64>>(&mut self, value: V) -> Result<usize> {
+        encode!(self.endian, value.borrow(), self.stream);
     }
 
     /// Write an `i64` to the stream.
-    pub fn write_i64(&mut self, value: i64) -> Result<usize> {
-        encode!(self.endian, &value, self.stream);
+    pub fn write_i64<V: Borrow<i64>>(&mut self, value: V) -> Result<usize> {
+        encode!(self.endian, value.borrow(), self.stream);
     }
 
     /// Write a `u32` to the stream.
-    pub fn write_u32(&mut self, value: u32) -> Result<usize> {
-        encode!(self.endian, &value, self.stream);
+    pub fn write_u32<V: Borrow<u32>>(&mut self, value: V) -> Result<usize> {
+        encode!(self.endian, value.borrow(), self.stream);
     }
 
     /// Write an `i32` to the stream.
-    pub fn write_i32(&mut self, value: i32) -> Result<usize> {
-        encode!(self.endian, &value, self.stream);
+    pub fn write_i32<V: Borrow<i32>>(&mut self, value: V) -> Result<usize> {
+        encode!(self.endian, value.borrow(), self.stream);
     }
 
     /// Write a `u16` to the stream.
-    pub fn write_u16(&mut self, value: u16) -> Result<usize> {
-        encode!(self.endian, &value, self.stream);
+    pub fn write_u16<V: Borrow<u16>>(&mut self, value: V) -> Result<usize> {
+        encode!(self.endian, value.borrow(), self.stream);
     }
 
     /// Write an `i16` to the stream.
-    pub fn write_i16(&mut self, value: i16) -> Result<usize> {
-        encode!(self.endian, &value, self.stream);
+    pub fn write_i16<V: Borrow<i16>>(&mut self, value: V) -> Result<usize> {
+        encode!(self.endian, value.borrow(), self.stream);
     }
 
     /// Write a `u8` to the stream.
-    pub fn write_u8(&mut self, value: u8) -> Result<usize> {
-        encode!(self.endian, &value, self.stream);
+    pub fn write_u8<V: Borrow<u8>>(&mut self, value: V) -> Result<usize> {
+        encode!(self.endian, value.borrow(), self.stream);
     }
 
     /// Write an `i8` to the stream.
-    pub fn write_i8(&mut self, value: i8) -> Result<usize> {
-        encode!(self.endian, &value, self.stream);
+    pub fn write_i8<V: Borrow<i8>>(&mut self, value: V) -> Result<usize> {
+        encode!(self.endian, value.borrow(), self.stream);
     }
 
     /// Write a byte buffer to the stream.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,20 +76,24 @@ pub struct BinaryReader<'a> {
     endian: Endian,
 }
 
+impl<'a> SeekStream for BinaryReader<'a> {
+    fn seek(&mut self, to: usize) -> Result<usize> {
+        self.stream.seek(to)
+    }
+
+    fn tell(&mut self) -> Result<usize> {
+        self.stream.tell()
+    }
+
+    fn len(&self) -> Result<usize> {
+        self.stream.len()
+    }
+}
+
 impl<'a> BinaryReader<'a> {
     /// Create a binary reader with the given endianness.
     pub fn new(stream: &'a mut impl ReadStream, endian: Endian) -> Self {
         Self { stream, endian }
-    }
-
-    /// Seek to a position.
-    pub fn seek(&mut self, to: usize) -> Result<usize> {
-        Ok(self.stream.seek(to)?)
-    }
-
-    /// Get the current position.
-    pub fn tell(&mut self) -> Result<usize> {
-        Ok(self.stream.tell()?)
     }
 
     /// Read a length-prefixed `String` from the stream.
@@ -235,20 +239,24 @@ pub struct BinaryWriter<'a> {
     endian: Endian,
 }
 
+impl<'a> SeekStream for BinaryWriter<'a> {
+    fn seek(&mut self, to: usize) -> Result<usize> {
+        self.stream.seek(to)
+    }
+
+    fn tell(&mut self) -> Result<usize> {
+        self.stream.tell()
+    }
+
+    fn len(&self) -> Result<usize> {
+        self.stream.len()
+    }
+}
+
 impl<'a> BinaryWriter<'a> {
     /// Create a binary writer with the given endianness.
     pub fn new(stream: &'a mut impl WriteStream, endian: Endian) -> Self {
         Self { stream, endian }
-    }
-
-    /// Seek to a position.
-    pub fn seek(&mut self, to: usize) -> Result<usize> {
-        Ok(self.stream.seek(to)?)
-    }
-
-    /// Get the current position.
-    pub fn tell(&mut self) -> Result<usize> {
-        Ok(self.stream.tell()?)
     }
 
     /// Write a length-prefixed `String` to the stream.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ impl Default for Endian {
 }
 
 /// Trait for streams that can seek.
-pub trait SeekableStream {
+pub trait SeekStream {
     /// Seek to a position.
     fn seek(&mut self, to: usize) -> Result<usize>;
     /// Get the current position.
@@ -65,10 +65,10 @@ pub trait SeekableStream {
 }
 
 /// Trait for a readable stream.
-pub trait ReadStream: Read + SeekableStream {}
+pub trait ReadStream: Read + SeekStream {}
 
 /// Trait for a writable stream.
-pub trait WriteStream: Write + SeekableStream {}
+pub trait WriteStream: Write + SeekStream {}
 
 /// Read from a stream.
 pub struct BinaryReader<'a> {

--- a/src/stream/file.rs
+++ b/src/stream/file.rs
@@ -1,5 +1,5 @@
 //! Stream for operating on files.
-use crate::{BinaryError, SeekableStream, ReadStream, Result, WriteStream};
+use crate::{BinaryError, SeekStream, ReadStream, Result, WriteStream};
 use std::fs::{self, OpenOptions};
 use std::io::prelude::*;
 use std::io::{Error, ErrorKind, Read, SeekFrom, Write};
@@ -36,7 +36,7 @@ impl FileStream {
     }
 }
 
-impl SeekableStream for FileStream {
+impl SeekStream for FileStream {
     fn seek(&mut self, to: usize) -> Result<usize> {
         Ok(self.file.seek(SeekFrom::Start(to as u64))? as usize)
     }

--- a/src/stream/file.rs
+++ b/src/stream/file.rs
@@ -1,5 +1,5 @@
 //! Stream for operating on files.
-use crate::{BinaryError, SeekStream, ReadStream, Result, WriteStream};
+use crate::{BinaryError, ReadStream, Result, SeekStream, WriteStream};
 use std::fs::{self, OpenOptions};
 use std::io::prelude::*;
 use std::io::{Error, ErrorKind, Read, SeekFrom, Write};
@@ -74,4 +74,3 @@ impl Write for FileStream {
 
 impl ReadStream for FileStream {}
 impl WriteStream for FileStream {}
-

--- a/src/stream/file.rs
+++ b/src/stream/file.rs
@@ -1,5 +1,5 @@
 //! Stream for operating on files.
-use crate::{Stream, Result, BinaryError};
+use crate::{BinaryError, SeekableStream, ReadStream, Result, WriteStream};
 use std::fs::{self, OpenOptions};
 use std::io::prelude::*;
 use std::io::{Error, ErrorKind, Read, SeekFrom, Write};
@@ -29,17 +29,14 @@ impl FileStream {
     pub fn new<P: AsRef<Path>>(path: P, open_type: OpenType) -> Result<FileStream> {
         let file = match open_type {
             OpenType::OpenAndCreate => fs::File::create(path)?,
-            OpenType::ReadWrite => OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open(path)?,
+            OpenType::ReadWrite => OpenOptions::new().read(true).write(true).open(path)?,
             OpenType::Open => fs::File::open(path)?,
         };
-        Ok(FileStream { file })
+        Ok(Self { file })
     }
 }
 
-impl Stream for FileStream {
+impl SeekableStream for FileStream {
     fn seek(&mut self, to: usize) -> Result<usize> {
         Ok(self.file.seek(SeekFrom::Start(to as u64))? as usize)
     }
@@ -74,3 +71,7 @@ impl Write for FileStream {
         self.file.flush()
     }
 }
+
+impl ReadStream for FileStream {}
+impl WriteStream for FileStream {}
+

--- a/src/stream/memory.rs
+++ b/src/stream/memory.rs
@@ -1,8 +1,8 @@
-//! Stream for operating on in-memory buffers.
-use crate::{Stream, BinaryError, Result};
+//! Stream that reads from and writes to an owned buffer.
+use crate::{BinaryError, SeekableStream, ReadStream, Result, WriteStream};
 use std::io::{Error, ErrorKind, Read, Write};
 
-/// Stream that wraps an in-memory buffer.
+/// Stream that wraps an owned buffer.
 pub struct MemoryStream {
     buffer: Vec<u8>,
     position: usize,
@@ -11,14 +11,14 @@ pub struct MemoryStream {
 impl MemoryStream {
     /// Create a memory stream.
     pub fn new() -> Self {
-        MemoryStream {
+        Self {
             buffer: Vec::new(),
             position: 0,
         }
     }
 }
 
-impl Stream for MemoryStream {
+impl SeekableStream for MemoryStream {
     fn seek(&mut self, to: usize) -> Result<usize> {
         self.position = to;
         Ok(self.position)
@@ -95,3 +95,7 @@ impl Into<Vec<u8>> for MemoryStream {
         self.buffer
     }
 }
+
+impl ReadStream for MemoryStream {}
+impl WriteStream for MemoryStream {}
+

--- a/src/stream/memory.rs
+++ b/src/stream/memory.rs
@@ -1,5 +1,5 @@
 //! Stream that reads from and writes to an owned buffer.
-use crate::{BinaryError, SeekableStream, ReadStream, Result, WriteStream};
+use crate::{BinaryError, SeekStream, ReadStream, Result, WriteStream};
 use std::io::{Error, ErrorKind, Read, Write};
 
 /// Stream that wraps an owned buffer.
@@ -18,7 +18,7 @@ impl MemoryStream {
     }
 }
 
-impl SeekableStream for MemoryStream {
+impl SeekStream for MemoryStream {
     fn seek(&mut self, to: usize) -> Result<usize> {
         self.position = to;
         Ok(self.position)

--- a/src/stream/memory.rs
+++ b/src/stream/memory.rs
@@ -1,5 +1,5 @@
 //! Stream that reads from and writes to an owned buffer.
-use crate::{BinaryError, SeekStream, ReadStream, Result, WriteStream};
+use crate::{BinaryError, ReadStream, Result, SeekStream, WriteStream};
 use std::io::{Error, ErrorKind, Read, Write};
 
 /// Stream that wraps an owned buffer.
@@ -98,4 +98,3 @@ impl Into<Vec<u8>> for MemoryStream {
 
 impl ReadStream for MemoryStream {}
 impl WriteStream for MemoryStream {}
-

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod file;
+pub(crate) mod memory;
+pub(crate) mod slice;

--- a/src/stream/slice.rs
+++ b/src/stream/slice.rs
@@ -1,0 +1,57 @@
+//! Stream that reads from a slice of bytes.
+use crate::{BinaryError, SeekableStream, ReadStream, Result};
+use std::io::{Error, ErrorKind, Read};
+
+/// Stream that wraps a slice of bytes.
+pub struct SliceStream<'a> {
+    buffer: &'a [u8],
+    position: usize,
+}
+
+impl<'a> SliceStream<'a> {
+    /// Create a slice stream.
+    pub fn new(buffer: &'a [u8]) -> Self {
+        Self {
+            buffer,
+            position: 0,
+        }
+    }
+}
+
+impl SeekableStream for SliceStream<'_> {
+    fn seek(&mut self, to: usize) -> Result<usize> {
+        self.position = to;
+        Ok(self.position)
+    }
+
+    fn tell(&mut self) -> Result<usize> {
+        Ok(self.position)
+    }
+
+    fn len(&self) -> Result<usize> {
+        Ok(self.buffer.len())
+    }
+}
+
+impl Read for SliceStream<'_> {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        if self.position + buffer.len() > self.buffer.len() {
+            return Err(Error::new(
+                ErrorKind::UnexpectedEof,
+                BinaryError::ReadPastEof,
+            ));
+        }
+
+        let mut idx = 0;
+        for i in self.position..self.position + buffer.len() {
+            buffer[idx] = self.buffer[i];
+            idx += 1;
+        }
+
+        self.position += buffer.len();
+
+        Ok(buffer.len())
+    }
+}
+
+impl ReadStream for SliceStream<'_> {}

--- a/src/stream/slice.rs
+++ b/src/stream/slice.rs
@@ -1,5 +1,5 @@
 //! Stream that reads from a slice of bytes.
-use crate::{BinaryError, SeekStream, ReadStream, Result};
+use crate::{BinaryError, ReadStream, Result, SeekStream};
 use std::io::{Error, ErrorKind, Read};
 
 /// Stream that wraps a slice of bytes.

--- a/src/stream/slice.rs
+++ b/src/stream/slice.rs
@@ -1,5 +1,5 @@
 //! Stream that reads from a slice of bytes.
-use crate::{BinaryError, SeekableStream, ReadStream, Result};
+use crate::{BinaryError, SeekStream, ReadStream, Result};
 use std::io::{Error, ErrorKind, Read};
 
 /// Stream that wraps a slice of bytes.
@@ -18,7 +18,7 @@ impl<'a> SliceStream<'a> {
     }
 }
 
-impl SeekableStream for SliceStream<'_> {
+impl SeekStream for SliceStream<'_> {
     fn seek(&mut self, to: usize) -> Result<usize> {
         self.position = to;
         Ok(self.position)

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
-use binary_rw::{Endian, BinaryReader, BinaryWriter, FileStream, MemoryStream, OpenType, SliceStream, SeekStream};
+use binary_rw::{
+    BinaryReader, BinaryWriter, Endian, FileStream, MemoryStream, OpenType, SeekStream, SliceStream,
+};
 
 fn create_writer_stream(name: &str) -> FileStream {
     let name = format!("{}.test", name);
@@ -14,6 +16,95 @@ fn create_reader_stream(name: &str) -> FileStream {
 fn cleanup(name: &str) {
     let name = format!("{}.test", name);
     std::fs::remove_file(&name).expect("Failure to delete file");
+}
+
+#[test]
+fn borrow_test() -> Result<()> {
+    let mut stream = MemoryStream::new();
+    let mut writer = BinaryWriter::new(&mut stream, Endian::Big);
+    writer.write_u8(8)?;
+    writer.write_u8(&8)?;
+    writer.write_i8(-8)?;
+    writer.write_i8(&-8)?;
+
+    writer.write_u16(16)?;
+    writer.write_u16(&16)?;
+    writer.write_i16(-16)?;
+    writer.write_i16(&-16)?;
+
+    writer.write_u32(32)?;
+    writer.write_u32(&32)?;
+    writer.write_i32(-32)?;
+    writer.write_i32(&-32)?;
+
+    writer.write_u64(64)?;
+    writer.write_u64(&64)?;
+    writer.write_i64(-64)?;
+    writer.write_i64(&-64)?;
+
+    writer.write_usize(64)?;
+    writer.write_usize(&64)?;
+    writer.write_isize(-64)?;
+    writer.write_isize(&-64)?;
+
+    writer.write_char('c')?;
+    writer.write_char(&'c')?;
+
+    writer.write_bool(true)?;
+    writer.write_bool(&true)?;
+
+    writer.write_string("foo")?;
+    writer.write_string(String::from("foo"))?;
+
+    let buf: Vec<u8> = vec![1, 2, 3, 4];
+    let exp: Vec<u8> = buf.clone(); // for assertion
+
+    writer.write_bytes(&buf)?;
+    writer.write_bytes(buf)?;
+
+    let buffer: Vec<u8> = stream.into();
+
+    let mut stream = SliceStream::new(&buffer);
+    let mut reader = BinaryReader::new(&mut stream, Endian::Big);
+
+    let value = (reader.read_u8()?, reader.read_u8()?);
+    assert_eq!((8, 8), value);
+    let value = (reader.read_i8()?, reader.read_i8()?);
+    assert_eq!((-8, -8), value);
+
+    let value = (reader.read_u16()?, reader.read_u16()?);
+    assert_eq!((16, 16), value);
+    let value = (reader.read_i16()?, reader.read_i16()?);
+    assert_eq!((-16, -16), value);
+
+    let value = (reader.read_u32()?, reader.read_u32()?);
+    assert_eq!((32, 32), value);
+    let value = (reader.read_i32()?, reader.read_i32()?);
+    assert_eq!((-32, -32), value);
+
+    let value = (reader.read_u64()?, reader.read_u64()?);
+    assert_eq!((64, 64), value);
+    let value = (reader.read_i64()?, reader.read_i64()?);
+    assert_eq!((-64, -64), value);
+
+    let value = (reader.read_usize()?, reader.read_usize()?);
+    assert_eq!((64, 64), value);
+    let value = (reader.read_isize()?, reader.read_isize()?);
+    assert_eq!((-64, -64), value);
+
+    let value = (reader.read_char()?, reader.read_char()?);
+    assert_eq!(('c', 'c'), value);
+
+    let value = (reader.read_bool()?, reader.read_bool()?);
+    assert_eq!((true, true), value);
+
+    let value = (reader.read_string()?, reader.read_string()?);
+    assert_eq!((String::from("foo"), String::from("foo")), value);
+
+    let value = (reader.read_bytes(4)?, reader.read_bytes(4)?);
+    assert_eq!((exp.clone(), exp), value);
+
+    Ok(())
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -115,6 +115,8 @@ fn slice_test() -> Result<()> {
     writer.write_string("foo")?;
     writer.write_char('b')?;
 
+    assert_eq!(19, writer.len()?);
+
     let buffer: Vec<u8> = stream.into();
 
     let mut stream = SliceStream::new(&buffer);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -28,11 +28,16 @@ fn slice_test() -> Result<()> {
     let mut stream = SliceStream::new(&buffer);
     let mut reader = BinaryReader::new(&mut stream, Endian::Big);
 
+    reader.seek(0)?;
     let value = reader.read_u32()?;
     assert_eq!(42, value);
 
+    assert_eq!(4, reader.tell()?);
+
     let value = reader.read_string()?;
     assert_eq!("foo", &value);
+
+    assert_eq!(15, reader.len()?);
 
     Ok(())
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -22,6 +22,7 @@ fn slice_test() -> Result<()> {
     let mut writer = BinaryWriter::new(&mut stream, Endian::Big);
     writer.write_u32(42)?;
     writer.write_string("foo")?;
+    writer.write_char('b')?;
 
     let buffer: Vec<u8> = stream.into();
 
@@ -37,7 +38,10 @@ fn slice_test() -> Result<()> {
     let value = reader.read_string()?;
     assert_eq!("foo", &value);
 
-    assert_eq!(15, reader.len()?);
+    let value = reader.read_char()?;
+    assert_eq!('b', value);
+
+    assert_eq!(19, reader.len()?);
 
     Ok(())
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use binary_rw::{Endian, BinaryReader, BinaryWriter, FileStream, MemoryStream, OpenType, SliceStream};
+use binary_rw::{Endian, BinaryReader, BinaryWriter, FileStream, MemoryStream, OpenType, SliceStream, SeekStream};
 
 fn create_writer_stream(name: &str) -> FileStream {
     let name = format!("{}.test", name);


### PR DESCRIPTION
Hi @mathias234, thanks for getting those last couple of PRs merged 👍 

I have another use case where I want to read from a stream but I don't want to pass ownership of the buffer to `MemoryStream`. This is so that I can validate that the data looks like what I expect by reading the file identity bytes and header information before sending it elsewhere to be processed.

The only way I could see this being achieved was to split the stream traits into `ReadStream` and `WriteStream` which I have done and added a `SliceStream` which allows us to read from `&[u8]`.

I also took the liberty of tidying the stream modules slightly by moving them into the `stream` folder and have bumped the major version as the `Stream` trait no longer exists.

A test spec for `SliceStream` has been added.

Hope you are ok with these changes and thanks as always for your help 🙏 