### PR TITLE
Added `write_bytes_with_value`  and `swap_endianness` for BinaryWriter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binary_rw"
-version = "4.0.2"
+version = "4.0.3"
 authors = ["Mathias Danielsen <mathiasda98@hotmail.com>"]
 edition = "2021"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,6 +362,13 @@ impl<'a> BinaryWriter<'a> {
     pub fn write_bytes<B: AsRef<[u8]>>(&mut self, data: B) -> Result<usize> {
         Ok(self.stream.write(data.as_ref())?)
     }
+
+    /// Write a byte buffer to the stream.
+    pub fn write_bytes_with_value(&mut self, count: usize, fill_value: u8) -> Result<usize> {
+        let mut buff = Vec::with_capacity(count) as Vec<u8>;
+        buff.resize(count, fill_value);
+        Ok(self.write_bytes(buff)?)
+    }
 }
 
 /// Trait for encoding to binary.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,6 +369,15 @@ impl<'a> BinaryWriter<'a> {
         buff.resize(count, fill_value);
         Ok(self.write_bytes(buff)?)
     }
+
+    /// Swap endianness to allow for reversing the writing mid stream
+    pub fn swap_endianness(&mut self) {
+        if self.endian == Endian::Big {
+            self.endian = Endian::Little;
+        } else {
+            self.endian = Endian::Big;
+        }
+    }
 }
 
 /// Trait for encoding to binary.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -534,6 +534,16 @@ fn write_to_memorystream_into_vec() -> Result<()> {
 }
 
 #[test]
+fn write_bytes_with_value() -> Result<()> {
+    let mut stream = MemoryStream::new();
+    let mut writer = BinaryWriter::new(&mut stream, Default::default());
+    writer.write_bytes_with_value(3, 1)?;
+    
+    assert_eq!(3, writer.len()?);
+    Ok(())
+}
+
+#[test]
 fn swap_endianness_swaps() -> Result<()> {
     let mut stream = MemoryStream::new();
     {


### PR DESCRIPTION
Added ability to write a series of a given character a number of times. Useful for writing a bunch of empty space.