### PR TITLE
Added string_len_u32 feature flag to use fixed sized string length

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 
 [features]
 wasm32 = []
+string_len_u32 = []
 
 [dependencies]
 thiserror = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ impl<'a> BinaryReader<'a> {
 
     /// Read a length-prefixed `String` from the stream.
     pub fn read_string(&mut self) -> Result<String> {
-        let chars = if cfg!(feature = "wasm32") {
+        let chars = if cfg!(any(feature = "wasm32", feature = "string_len_u32")) {
             let str_len = self.read_u32()?;
             let mut chars: Vec<u8> = vec![0; str_len as usize];
             self.stream.read_exact(&mut chars)?;
@@ -118,7 +118,7 @@ impl<'a> BinaryReader<'a> {
 
     /// Read a 7bit encoded length-prefixed `String` from the stream.
     pub fn read_7bit_encoded_len_string(&mut self) -> Result<String> {
-        let chars = if cfg!(feature = "wasm32") {
+        let chars = if cfg!(any(feature = "wasm32", feature = "string_len_u32")) {
             let str_len = self.read_7bit_encoded_u32()?;
             let mut chars: Vec<u8> = vec![0; str_len as usize];
             self.stream.read_exact(&mut chars)?;
@@ -345,11 +345,11 @@ impl<'a> BinaryWriter<'a> {
     /// Write a length-prefixed `String` to the stream.
     ///
     /// The length of the `String` is written as a `usize`
-    /// unless the `wasm32` feature is enabled
+    /// unless the `wasm32` or `string_len_u32` feature is enabled
     /// in which case the length is a `u32`.
     pub fn write_string<S: AsRef<str>>(&mut self, value: S) -> Result<usize> {
         let bytes = value.as_ref().as_bytes();
-        if cfg!(feature = "wasm32") {
+        if cfg!(any(feature = "wasm32", feature = "string_len_u32")) {
             self.write_u32(bytes.len() as u32)?;
         } else {
             self.write_usize(bytes.len())?;
@@ -360,11 +360,11 @@ impl<'a> BinaryWriter<'a> {
     /// Write a 7bit encoded length-prefixed `String` to the stream.
     ///
     /// The length of the `String` is written as a 7bit encoded `usize`
-    /// unless the `wasm32` feature is enabled
+    /// unless the `wasm32` or `string_len_u32` feature is enabled
     /// in which case the length is a 7bit encoded `u32`.
     pub fn write_7bit_encoded_len_string<S: AsRef<str>>(&mut self, value: S) -> Result<usize> {
         let bytes = value.as_ref().as_bytes();
-        if cfg!(feature = "wasm32") {
+        if cfg!(any(feature = "wasm32", feature = "string_len_u32")) {
             self.write_7bit_encoded_u32(bytes.len() as u32)?;
         } else {
             self.write_7bit_encoded_usize(bytes.len())?;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -109,6 +109,12 @@ fn borrow_test() -> Result<()> {
 
 #[test]
 fn slice_test() -> Result<()> {
+    let size: usize = if cfg!(any(feature = "wasm32", feature = "string_len_u32")) {
+        19
+    } else {
+        23
+    };
+
     let mut stream = MemoryStream::new();
     let mut writer = BinaryWriter::new(&mut stream, Endian::Big);
     writer.write_u32(42)?;
@@ -116,7 +122,7 @@ fn slice_test() -> Result<()> {
     writer.write_7bit_encoded_len_string("bar")?;
     writer.write_char('b')?;
 
-    assert_eq!(23, writer.len()?);
+    assert_eq!(size, writer.len()?);
 
     let buffer: Vec<u8> = stream.into();
 
@@ -138,7 +144,7 @@ fn slice_test() -> Result<()> {
     let value = reader.read_char()?;
     assert_eq!('b', value);
 
-    assert_eq!(23, reader.len()?);
+    assert_eq!(size, reader.len()?);
 
     Ok(())
 }


### PR DESCRIPTION
Probably this is unnecessary change, due to wasm32 provides similar behaviour already. 
Might be just naming issue. 
Decline if thing so.